### PR TITLE
Make is_* and to_* subs faster

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for MooseX-Types
 
 {{$NEXT}}
+        - made the exported is_Foo and to_Foo subs much faster, especially for
+          type constraints which can be inlined.
 
 0.48      2016-12-07 01:15:14Z
         - reverted is_Foo and to_Foo refactoring [from 0.47] for now, so they

--- a/eg/benchmarks.pl
+++ b/eg/benchmarks.pl
@@ -1,0 +1,91 @@
+use strict;
+use warnings;
+
+{
+    package MXT;
+
+    use MooseX::Types -declare => [qw( HasCoercion NonInline )];
+    use MooseX::Types::Moose qw( Int Num Value );
+
+    subtype HasCoercion, as Int;
+    coerce HasCoercion,
+        from Num,
+        via { return int( $_[0] ) };
+
+    subtype NonInline,
+        as Value,
+        where { $_ eq 'foo' || $_ eq 'bar' };
+}
+
+{
+    package T;
+
+    use Moose::Util::TypeConstraints;
+
+    our $arrayref   = find_type_constraint('ArrayRef');
+    our $int        = find_type_constraint('Int');
+    our $str        = find_type_constraint('Str');
+    our $non_inline = subtype(
+        as 'Value',
+        where { $_ eq 'foo' || $_ eq 'bar' },
+    );
+}
+
+use Benchmark qw( cmpthese timethese );
+
+use MooseX::Types::Moose qw( ArrayRef Int Str );
+MXT->import( qw( HasCoercion NonInline ) );
+
+my @items = ( undef, 42, 42.123, 'foo', [], {}, $T::arrayref );
+
+sub plain_moose {
+    for my $item (@items) {
+        $T::arrayref->check($item);
+        $T::int->check($item);
+        $T::str->check($item);
+        $T::non_inline->check($item);
+    }
+}
+
+sub moosex_types_is {
+    for my $item (@items) {
+        is_ArrayRef($item);
+        is_Int($item);
+        is_Str($item);
+        is_NonInline($item);
+    }
+}
+
+sub moosex_types_check {
+    for my $item (@items) {
+        ArrayRef()->check($item);
+        Int()->check($item);
+        Str()->check($item);
+        NonInline()->check($item);
+    }
+}
+
+print "\n";
+
+cmpthese(
+    50_000,
+    {
+        'HasCoercion()->coerce' => sub {
+            HasCoercion()->coerce($_) for @items;
+        },
+        'to_HasCoercion' => sub {
+            to_HasCoercion($_) for @items;
+        },
+    },
+);
+
+print "\n";
+
+cmpthese(
+    50_000,
+    {
+        'plain Moose'                 => \&plain_moose,
+        'MooseX::Types is_*'          => \&moosex_types_is,
+        'MooseX::Types Type()->check' => \&moosex_types_check,
+    },
+);

--- a/lib/MooseX/Types/Base.pm
+++ b/lib/MooseX/Types/Base.pm
@@ -76,17 +76,20 @@ sub import {
             };
 
         # the check helper
+        my $check_name = "is_${type_short}";
         push @{ $ex_spec{exports} },
-            "is_${type_short}",
-            sub { $wrapper->check_export_generator($type_short, $type_full, $undef_msg) };
+            $check_name,
+            sub { $wrapper->check_export_generator($type_short, $type_full, $undef_msg, $check_name) };
 
         # only export coercion helper if full (for libraries) or coercion is defined
         next TYPE
             unless $options->{ -full }
             or ($type_cons and $type_cons->has_coercion);
+
+        my $coercion_name = "to_${type_short}";
         push @{ $ex_spec{exports} },
-            "to_${type_short}",
-            sub { $wrapper->coercion_export_generator($type_short, $type_full, $undef_msg) };
+            $coercion_name,
+            sub { $wrapper->coercion_export_generator($type_short, $type_full, $undef_msg, $coercion_name) };
         $ex_util{ $type_short }{to}++;  # shortcut to remember this exists
     }
 

--- a/lib/MooseX/Types/Base.pm
+++ b/lib/MooseX/Types/Base.pm
@@ -43,7 +43,7 @@ sub import {
     delete @ex_spec{ qw(-wrapper -into -full) };
 
     unless ($options) {
-        $options = {foo => 23};
+        $options = {};
         unshift @args, $options;
     }
 

--- a/lib/MooseX/Types/Base.pm
+++ b/lib/MooseX/Types/Base.pm
@@ -79,7 +79,7 @@ sub import {
         my $check_name = "is_${type_short}";
         push @{ $ex_spec{exports} },
             $check_name,
-            sub { $wrapper->check_export_generator($type_short, $type_full, $undef_msg, $check_name) };
+            sub { $wrapper->check_export_generator($type_short, $type_full, $undef_msg) };
 
         # only export coercion helper if full (for libraries) or coercion is defined
         next TYPE
@@ -89,7 +89,7 @@ sub import {
         my $coercion_name = "to_${type_short}";
         push @{ $ex_spec{exports} },
             $coercion_name,
-            sub { $wrapper->coercion_export_generator($type_short, $type_full, $undef_msg, $coercion_name) };
+            sub { $wrapper->coercion_export_generator($type_short, $type_full, $undef_msg) };
         $ex_util{ $type_short }{to}++;  # shortcut to remember this exists
     }
 

--- a/t/11_library-definition.t
+++ b/t/11_library-definition.t
@@ -13,6 +13,28 @@ my @tests = (
     [ 'IntArrayRef', 12, [12], {}, [17, 23], {} ],
 );
 
+{
+    is_deeply(
+        to_IntArrayRef(42), [42],
+        'to_IntArrayRef works on first call'
+    );
+    is_deeply(
+        to_IntArrayRef(84), [84],
+        'to_IntArrayRef works on second call and does not close over first value'
+    );
+}
+
+{
+    ok(
+        is_IntArrayRef([42]),
+        'is_IntArrayRef works on first call'
+    );
+    ok(
+        !is_IntArrayRef({}),
+        'to_IntArrayRef works on second call and does not close over first value'
+    );
+}
+
 # new array ref so we can safely shift from it
 for my $data (map { [@$_] } @tests) {
     my $type = shift @$data;


### PR DESCRIPTION
Before ths branch:

```
                         Rate HasCoercion()->coerce        to_HasCoercion
HasCoercion()->coerce  3477/s                    --                  -79%
to_HasCoercion        16779/s                  383%                    --

                               Rate MooseX::Types Type()->check MooseX::Types is_* plain Moose
MooseX::Types Type()->check  1214/s                          --               -87%        -95%
MooseX::Types is_*           9225/s                        660%                 --        -62%
plain Moose                 24390/s                       1909%               164%          --
```

And after:

```
                         Rate HasCoercion()->coerce        to_HasCoercion
HasCoercion()->coerce  3644/s                    --                  -84%
to_HasCoercion        22727/s                  524%                    --

                               Rate MooseX::Types Type()->check plain Moose MooseX::Types is_*
MooseX::Types Type()->check  1258/s                          --        -95%               -97%
plain Moose                 24631/s                       1857%          --               -39%
MooseX::Types is_*          40650/s                       3130%         65%                 --
```