### PR TITLE
Set sub names when calling defer_sub

### DIFF
--- a/lib/MooseX/Types.pm
+++ b/lib/MooseX/Types.pm
@@ -486,8 +486,8 @@ This generates a coercion handler function, e.g. C<to_Int($value)>.
 =cut
 
 sub coercion_export_generator {
-    my ($class, $type, $full, $undef_msg) = @_;
-    return defer_sub undef, sub {
+    my ($class, $sub_name, $type, $full, $undef_msg) = @_;
+    return defer_sub $sub_name, sub {
         my ($value) = @_;
 
         # we need a type object
@@ -511,9 +511,9 @@ Generates a constraint check closure, e.g. C<is_Int($value)>.
 =cut
 
 sub check_export_generator {
-    my ($class, $type, $full, $undef_msg) = @_;
+    my ($class, $sub_name, $type, $full, $undef_msg) = @_;
 
-    return defer_sub undef, sub {
+    return defer_sub $sub_name, sub {
         my ($value) = @_;
 
         # we need a type object

--- a/t/27-sub-defer.t
+++ b/t/27-sub-defer.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+
+use Test::Fatal;
+use B::Deparse;
+use MooseX::Types::Moose qw( Int );
+use Sub::Defer qw( undefer_all );
+
+like(
+    B::Deparse->new->coderef2text( \&is_Int ),
+    qr/package Sub::Defer/,
+    'is_Int sub has not yet been undeferred'
+);
+is(
+    exception { undefer_all() },
+    undef,
+    'Sub::Defer::undefer_all works with subs exported by MooseX::Types'
+);
+unlike(
+    B::Deparse->new->coderef2text( \&is_Int ),
+    qr/package Sub::Defer/,
+    'is_Int sub is now undeferred'
+);
+
+done_testing();


### PR DESCRIPTION
I was trying to fix https://rt.cpan.org/Ticket/Display.html?id=119534. This doesn't fix it, but I think these changes are still worth making. AFAICT, Sub::Defer really wants us to pass in a sub name.